### PR TITLE
Allow websockets to be used with logging wrapper.

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -4,6 +4,7 @@ package logging
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -124,7 +125,7 @@ func (w *responseWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hijacker, ok := w.w.(http.Hijacker); ok {
 		return hijacker.Hijack()
 	} else {
-		panic("http-handlers: ResponseWriter does not implement http.Hijacker")
+		return nil, nil, errors.New("http-handler: wrapped responsewrapper does not implement http.Hijack")
 	}
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -3,8 +3,10 @@
 package logging
 
 import (
+	"bufio"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -116,6 +118,14 @@ func (w *responseWrapper) Write(b []byte) (int, error) {
 func (w *responseWrapper) WriteHeader(status int) {
 	w.status = status
 	w.w.WriteHeader(status)
+}
+
+func (w *responseWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.w.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	} else {
+		panic("http-handlers: ResponseWriter does not implement http.Hijacker")
+	}
 }
 
 type clock func() time.Time


### PR DESCRIPTION
Websocket libraries need the responseWriter to also implement http.Hijacker in order to be able to upgrade the request into a websocket. Currently, the wrapped response in logging doesn't implement it, even if the underlying response does.

Doing something like this is necessary in order to be able to use logging with websockets. I'm not totally happy with this solution, because you lose a bit of typesafety. Whatever calls Hijack() is thinks that the response actually does implement it, and then it just panics instead. Ideally, the caller should be able to use the `x, ok := r.(http.Hijacker)` idiom to figure out of the underlying response can support Hijack, but I'm not sure if there's any way of doing this.
